### PR TITLE
chore: 🔧 .gitignoreにPodsディレクトリの除外を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ playground.xcworkspace
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-# Pods/
+Pods/
 # Add this line if you want to avoid checking in source code from the Xcode workspace
 # *.xcworkspace
 


### PR DESCRIPTION
### 修正内容
`.gitignore` ファイルを更新し、CocoaPodsの `Pods/` ディレクトリを除外するようにしました。

### 修正理由
将来的にCocoaPodsを使用する場合に備え、`Pods/` ディレクトリが誤ってコミットされるのを防ぐため。

### 参考資料
- [CocoaPods: Should I check the Pods directory into source control?](https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control)
