### PR TITLE
refactor: ✨ ネストを浅くする  #1

### DIFF
--- a/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
@@ -36,23 +36,17 @@ class RepositoryDetailViewController: UIViewController {
         
     }
     
-    func getImage(){
-        
+    func getImage() {
         let repository = repositorySearchViewController.repositories[repositorySearchViewController.selectedIndex]
-        
         titleLabel.text = repository["full_name"] as? String
-        
-        if let owner = repository["owner"] as? [String: Any] {
-            if let imgURL = owner["avatar_url"] as? String {
-                URLSession.shared.dataTask(with: URL(string: imgURL)!) { (data, res, err) in
-                    let image = UIImage(data: data!)!
-                    DispatchQueue.main.async {
-                        self.imageView.image = image
-                    }
-                }.resume()
+        guard let owner = repository["owner"] as? [String: Any] else { return }
+        guard let imgURL = owner["avatar_url"] as? String else { return }
+        URLSession.shared.dataTask(with: URL(string: imgURL)!) { (data, res, err) in
+            let img = UIImage(data: data!)!
+            DispatchQueue.main.async {
+                self.imageView.image = img
             }
-        }
-        
+        }.resume()
     }
     
 }


### PR DESCRIPTION
### 修正内容
- RepositorySearchViewControllerクラスのsearchBarSearchButtonClickedメソッドのネストを浅く修正
- RepositorySearchViewControllerクラスのprepareメソッドのネストを浅く修正
- RepositoryDetailViewControllerクラスのgetImageメソッドのネストを浅く修正

### 修正理由
- コードの可読性と保守性を向上させるため、ネストを浅くしました。