### PR TITLE
Issue 02 refactor force unwrapping

### DIFF
--- a/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
@@ -34,11 +34,12 @@ class RepositoryDetailViewController: UIViewController {
         let repository = repositorySearchViewController.searchRepositories[repositorySearchViewController.selectedRowIndex]
         repositoryNameLabel.text = repository["full_name"] as? String
         guard let owner = repository["owner"] as? [String: Any] else { return }
-        guard let imgURL = owner["avatar_url"] as? String else { return }
-        URLSession.shared.dataTask(with: URL(string: imgURL)!) { (data, res, err) in
-            let img = UIImage(data: data!)!
+        guard let avatarURLString = owner["avatar_url"] as? String else { return }
+        guard let avatarURL = URL(string: avatarURLString) else { return }
+        URLSession.shared.dataTask(with: avatarURL) { (data, response, error) in
+            guard let imageData = data, let image = UIImage(data: imageData) else { return }
             DispatchQueue.main.async {
-                self.repositoryImageView.image = img
+                self.repositoryImageView.image = image
             }
         }.resume()
     }

--- a/iOSEngineerCodeCheck/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/RepositorySearchViewController.swift
@@ -34,10 +34,12 @@ class RepositorySearchViewController: UITableViewController, UISearchBarDelegate
     }
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        searchTerm = searchBar.text!
-        guard searchTerm.count != 0 else { return }
-        searchAPIURLString = "https://api.github.com/search/repositories?q=\(searchTerm!)"
-        URLSession.shared.dataTask(with: URL(string: searchAPIURLString)!) { [weak self] data, response, error in
+        guard let searchTerm = searchBar.text, !searchTerm.isEmpty else { return }
+        self.searchTerm = searchTerm
+        searchAPIURLString = "https://api.github.com/search/repositories?q=\(searchTerm)"
+        guard let url = URL(string: searchAPIURLString) else { return }
+        URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
+            
             guard let self = self else { return }
             guard let data = data, let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
             if let items = json["items"] as? [[String: Any]] {
@@ -51,7 +53,7 @@ class RepositorySearchViewController: UITableViewController, UISearchBarDelegate
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard segue.identifier == "Detail" else { return }
-        let repositoryDetailViewController = segue.destination as! RepositoryDetailViewController
+        guard let repositoryDetailViewController = segue.destination as? RepositoryDetailViewController else { return }
         repositoryDetailViewController.repositorySearchViewController = self
     }
     


### PR DESCRIPTION
### 修正内容

- `RepositorySearchViewController`クラス：
  - `searchBar.text`のアンラップを`guard`文で安全に処理。
  - URLの生成時にアンラップを避けるため`guard`文を使用。
  - `segue.destination`のキャストを安全に行うため`guard`文を使用。

- `RepositoryDetailViewController`クラス：
  - `fetchRepositoryImage`メソッド内の強制アンラップを`guard`文で安全に処理。
  - 強制アンラップの修正に伴う変数の追加と、変数名の修正。


### 修正理由
- 強制アンラップはクラッシュの原因となり得るため、安全なコードを維持するためには避けるべきです。`guard`文を使用することで、値が存在することを確認し、安全に処理を進めることができます。
