### PR TITLE
refactor: ✨ #2 不必要なIUOの削除と安全なアンラップの実装

### DIFF
--- a/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
@@ -17,7 +17,8 @@ class RepositoryDetailViewController: UIViewController {
     @IBOutlet weak var watchersCountLabel: UILabel!
     @IBOutlet weak var forksCountLabel: UILabel!
     @IBOutlet weak var openIssuesCountLabel: UILabel!
-    var repositorySearchViewController: RepositorySearchViewController!
+    var repositorySearchViewController: RepositorySearchViewController?
+
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
@@ -21,7 +21,10 @@ class RepositoryDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        let repository = repositorySearchViewController.searchRepositories[repositorySearchViewController.selectedRowIndex]
+        guard let searchViewController = repositorySearchViewController else { return }
+        guard let selectedIndex = searchViewController.selectedRowIndex else { return }
+        let repository = searchViewController.searchRepositories[selectedIndex]
+        
         programmingLanguageLabel.text = "Written in \(repository["language"] as? String ?? "")"
         stargazersCountLabel.text = "\(repository["stargazers_count"] as? Int ?? 0) stars"
         watchersCountLabel.text = "\(repository["wachers_count"] as? Int ?? 0) watchers"
@@ -31,7 +34,9 @@ class RepositoryDetailViewController: UIViewController {
     }
     
     func fetchRepositoryImage() {
-        let repository = repositorySearchViewController.searchRepositories[repositorySearchViewController.selectedRowIndex]
+        guard let searchViewController = repositorySearchViewController else { return }
+        guard let selectedIndex = searchViewController.selectedRowIndex else { return }
+        let repository = searchViewController.searchRepositories[selectedIndex]
         repositoryNameLabel.text = repository["full_name"] as? String
         guard let owner = repository["owner"] as? [String: Any] else { return }
         guard let avatarURLString = owner["avatar_url"] as? String else { return }

--- a/iOSEngineerCodeCheck/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/RepositorySearchViewController.swift
@@ -13,9 +13,8 @@ class RepositorySearchViewController: UITableViewController, UISearchBarDelegate
     @IBOutlet weak var searchBar: UISearchBar!
     var searchRepositories: [[String: Any]] = []
     var searchTaskForRepositories: URLSessionTask?
-    var searchTerm: String!
-    var searchAPIURLString: String!
-    var selectedRowIndex: Int!
+    var searchTerm: String?
+    var selectedRowIndex: Int?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -36,8 +35,8 @@ class RepositorySearchViewController: UITableViewController, UISearchBarDelegate
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let searchTerm = searchBar.text, !searchTerm.isEmpty else { return }
         self.searchTerm = searchTerm
-        searchAPIURLString = "https://api.github.com/search/repositories?q=\(searchTerm)"
-        guard let url = URL(string: searchAPIURLString) else { return }
+        let apiURLString = "https://api.github.com/search/repositories?q=\(searchTerm)"
+        guard let url = URL(string: apiURLString) else { return }
         URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
             
             guard let self = self else { return }


### PR DESCRIPTION
### 修正内容
- `RepositorySearchViewController`クラス:
  - `searchTerm`と`selectedRowIndex`の不必要なIUOを削除し、オプショナルとして宣言
  - `searchAPIURLString`プロパティを削除し、ローカル変数として使用
  - RepositorySearchViewControllerクラスの変数の更新に伴い`RepositoryDetailViewController`クラスで`repositorySearchViewController`と`selectedRowIndex`を`guard`文で安全にアンラップ

- `RepositoryDetailViewController`クラス:
  - `repositorySearchViewController`の不必要なIUOを削除し、オプショナルとして宣言
  - `viewDidLoad`および`fetchRepositoryImage`メソッド内で`repositorySearchViewController`と`selectedRowIndex`を`guard`文で安全にアンラップ

### 修正理由
IUOはクラッシュの原因となる可能性があり、コードの安全性を低下させます。このプルリクエストでは、オプショナルバインディングを使用することで、安全にアンラップを行い、コードの堅牢性を高めました。