### PR TITLE
fix: ✨ #2 想定外のnilの握り潰しを防ぎ、エラーメッセージをユーザーに表示

### DIFF
--- a/iOSEngineerCodeCheck/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/RepositorySearchViewController.swift
@@ -40,7 +40,14 @@ class RepositorySearchViewController: UITableViewController, UISearchBarDelegate
         URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
             
             guard let self = self else { return }
-            guard let data = data, let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+            guard let data = data, let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                print("Failed to fetch JSON data")
+                // ユーザーにエラーメッセージを表示
+                DispatchQueue.main.async {
+                    self.showErrorAlert(message: "データの取得に失敗しました。インターネット接続を確認してください。")
+                }
+                return
+            }
             if let items = json["items"] as? [[String: Any]] {
                 self.searchRepositories = items
                 DispatchQueue.main.async {
@@ -48,6 +55,14 @@ class RepositorySearchViewController: UITableViewController, UISearchBarDelegate
                 }
             }
         }.resume()  // データタスクを実行
+    }
+    
+    // エラーメッセージを表示するためのヘルパーメソッド
+    func showErrorAlert(message: String) {
+        let alertController = UIAlertController(title: "エラー", message: message, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+        alertController.addAction(okAction)
+        present(alertController, animated: true, completion: nil)
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {


### PR DESCRIPTION
### 修正内容
- `searchBarSearchButtonClicked`メソッド内でデータの取得に失敗した場合のエラーハンドリングを追加
- データの取得に失敗した際にコンソールにエラーメッセージを出力
- データの取得に失敗した場合、ユーザーにエラーメッセージを表示する`showErrorAlert`メソッドを追加
- エラーメッセージを表示するための`UIAlertController`の実装

### 修正理由
データの取得に失敗した場合に、ユーザーに適切なフィードバックを提供し、ユーザーエクスペリエンスを向上させるため。また、想定外の`nil`を適切に処理することで、アプリの信頼性と安定性を向上させるため。

### 参考資料
- Apple公式ドキュメント: [UIAlertController](https://developer.apple.com/documentation/uikit/uialertcontroller)
