### PR TITLE
refactor: ✨ #5 CQS原則に基づきリファクタリング

### DIFF
--- a/iOSEngineerCodeCheck/Services/NetworkManager.swift
+++ b/iOSEngineerCodeCheck/Services/NetworkManager.swift
@@ -48,18 +48,22 @@ class NetworkManager {
     func cancelSearch() {
         searchTask?.cancel()
     }
+    
     func fetchRepositoryImage(from urlString: String, completion: @escaping (Result<UIImage?, Error>) -> Void) {
         guard let imgURL = URL(string: urlString) else {
-            completion(.failure(NSError(domain: "Invalid URL", code: -1, userInfo: nil)))
+            let error = NSError(domain: "Invalid URL", code: -1, userInfo: nil)
+            completion(.failure(error))
             return
         }
-        
-        URLSession.shared.dataTask(with: imgURL) { data, _, error in
+        fetchImage(from: imgURL, completion: completion)
+    }
+
+    private func fetchImage(from url: URL, completion: @escaping (Result<UIImage?, Error>) -> Void) {
+        URLSession.shared.dataTask(with: url) { data, _, error in
             if let error = error {
                 completion(.failure(error))
                 return
             }
-            
             if let data = data, let img = UIImage(data: data) {
                 completion(.success(img))
             } else {

--- a/iOSEngineerCodeCheck/Views/ViewControllers/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/Views/ViewControllers/RepositorySearchViewController.swift
@@ -51,19 +51,26 @@ class RepositorySearchViewController: UIViewController, UITableViewDelegate, UIT
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let searchTerm = searchBar.text, !searchTerm.isEmpty else { return }
+        searchRepositories(with: searchTerm)
+    }
 
+    private func searchRepositories(with searchTerm: String) {
         NetworkManager.shared.searchRepositories(with: searchTerm) { [weak self] result in
             guard let self = self else { return }
-            switch result {
-            case .success(let repositories):
-                self.searchRepositories = repositories
-                DispatchQueue.main.async {
-                    self.tableView.reloadData()
-                }
-            case .failure(let error):
-                DispatchQueue.main.async {
-                    self.showErrorAlert(for: error)
-                }
+            self.handleSearchResult(result)
+        }
+    }
+
+    private func handleSearchResult(_ result: Result<[RepositoryModel], Error>) {
+        switch result {
+        case .success(let repositories):
+            self.searchRepositories = repositories
+            DispatchQueue.main.async {
+                self.tableView.reloadData()
+            }
+        case .failure(let error):
+            DispatchQueue.main.async {
+                self.showErrorAlert(for: error)
             }
         }
     }


### PR DESCRIPTION
### 修正内容
- NetworkManager の画像フェッチ処理をCQS原則に基づきリファクタリング
- RepositorySearchViewControllerクラスのsearchBarSearchButtonClickedメソッドをCQS原則に基づきリファクタリング

### 修正理由
- NetworkManager のリファクタリング理由
  - 画像フェッチ処理を分離することで、コードの重複を排除し、再利用性を高めるため
  - コードの可読性を向上させ、将来的な保守性を向上させるため
- RepositorySearchViewControllerクラスのリファクタリング理由
  - 検索処理と検索結果の処理を分離することで、CQS原則に従い、コードの明確化と保守性を高めるため
  - メソッドを分割することで、各メソッドの責任を明確にし、コードの可読性を向上させるため