### PR TITLE
refactor: ✨ #5 NetworkManagerを単一責任原則に基づきリファクタリング

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		BFD945EB244DC5EB0012785A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */; };
 		BFD945F6244DC5EB0012785A /* iOSEngineerCodeCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945F5244DC5EB0012785A /* iOSEngineerCodeCheckTests.swift */; };
 		BFD94601244DC5EC0012785A /* iOSEngineerCodeCheckUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD94600244DC5EC0012785A /* iOSEngineerCodeCheckUITests.swift */; };
-		E2054CE22C1F150F0044D738 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2054CE12C1F150F0044D738 /* NetworkManager.swift */; };
+		E2054CE22C1F150F0044D738 /* GitHubRepositorySearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2054CE12C1F150F0044D738 /* GitHubRepositorySearcher.swift */; };
 		E2054CE42C1F15620044D738 /* RepositoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2054CE32C1F15610044D738 /* RepositoryModel.swift */; };
 		E28F1FA12C1E153E00591A37 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28F1FA02C1E153E00591A37 /* Extensions.swift */; };
 		E2E185702C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E1856F2C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift */; };
@@ -53,7 +53,7 @@
 		BFD945FC244DC5EB0012785A /* iOSEngineerCodeCheckUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSEngineerCodeCheckUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD94600244DC5EC0012785A /* iOSEngineerCodeCheckUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSEngineerCodeCheckUITests.swift; sourceTree = "<group>"; };
 		BFD94602244DC5EC0012785A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		E2054CE12C1F150F0044D738 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		E2054CE12C1F150F0044D738 /* GitHubRepositorySearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositorySearcher.swift; sourceTree = "<group>"; };
 		E2054CE32C1F15610044D738 /* RepositoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryModel.swift; sourceTree = "<group>"; };
 		E28F1FA02C1E153E00591A37 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		E2E1856F2C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryImageFetcher.swift; sourceTree = "<group>"; };
@@ -173,7 +173,7 @@
 		E288B0DC2C1F2C0000607ED0 /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				E2054CE12C1F150F0044D738 /* NetworkManager.swift */,
+				E2054CE12C1F150F0044D738 /* GitHubRepositorySearcher.swift */,
 				E2E1856F2C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift */,
 			);
 			path = Services;
@@ -327,7 +327,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E2054CE22C1F150F0044D738 /* NetworkManager.swift in Sources */,
+				E2054CE22C1F150F0044D738 /* GitHubRepositorySearcher.swift in Sources */,
 				E28F1FA12C1E153E00591A37 /* Extensions.swift in Sources */,
 				BFD945E3244DC5E80012785A /* RepositorySearchViewController.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		E2054CE22C1F150F0044D738 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2054CE12C1F150F0044D738 /* NetworkManager.swift */; };
 		E2054CE42C1F15620044D738 /* RepositoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2054CE32C1F15610044D738 /* RepositoryModel.swift */; };
 		E28F1FA12C1E153E00591A37 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28F1FA02C1E153E00591A37 /* Extensions.swift */; };
+		E2E185702C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E1856F2C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +56,7 @@
 		E2054CE12C1F150F0044D738 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		E2054CE32C1F15610044D738 /* RepositoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryModel.swift; sourceTree = "<group>"; };
 		E28F1FA02C1E153E00591A37 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		E2E1856F2C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryImageFetcher.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -172,6 +174,7 @@
 			isa = PBXGroup;
 			children = (
 				E2054CE12C1F150F0044D738 /* NetworkManager.swift */,
+				E2E1856F2C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -328,6 +331,7 @@
 				E28F1FA12C1E153E00591A37 /* Extensions.swift in Sources */,
 				BFD945E3244DC5E80012785A /* RepositorySearchViewController.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */,
+				E2E185702C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				E2054CE42C1F15620044D738 /* RepositoryModel.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,

--- a/iOSEngineerCodeCheck/Services/GitHubRepositoryImageFetcher.swift
+++ b/iOSEngineerCodeCheck/Services/GitHubRepositoryImageFetcher.swift
@@ -1,0 +1,38 @@
+//
+//  GitHubRepositoryImageFetcher.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 鈴木斗夢 on 2024/06/17.
+//  Copyright © 2024 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+class GitHubRepositoryImageFetcher {
+    // シングルトンパターンを利用するためNetworkManagerクラスのインスタン化を禁止
+    private init() {}
+    static let shared = GitHubRepositoryImageFetcher()
+    
+    func fetchRepositoryImage(from urlString: String, completion: @escaping (Result<UIImage?, Error>) -> Void) {
+        guard let imgURL = URL(string: urlString) else {
+            let error = NSError(domain: "Invalid URL", code: -1, userInfo: nil)
+            completion(.failure(error))
+            return
+        }
+        fetchImage(from: imgURL, completion: completion)
+    }
+
+    private func fetchImage(from url: URL, completion: @escaping (Result<UIImage?, Error>) -> Void) {
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            if let data = data, let img = UIImage(data: data) {
+                completion(.success(img))
+            } else {
+                completion(.success(nil))
+            }
+        }.resume()
+    }
+}

--- a/iOSEngineerCodeCheck/Services/GitHubRepositorySearcher.swift
+++ b/iOSEngineerCodeCheck/Services/GitHubRepositorySearcher.swift
@@ -8,12 +8,11 @@
 
 import UIKit
 
-class NetworkManager {
+class GitHubRepositorySearcher {
     private var searchTask: URLSessionTask?
-    
     // シングルトンパターンを利用するためNetworkManagerクラスのインスタン化を禁止
     private init() {}
-    static let shared = NetworkManager()
+    static let shared = GitHubRepositorySearcher()
     
     func searchRepositories(with searchTerm: String, completion: @escaping (Result<[RepositoryModel], Error>) -> Void) {
         let searchAPIURLString = "https://api.github.com/search/repositories?q=\(searchTerm)"

--- a/iOSEngineerCodeCheck/Services/NetworkManager.swift
+++ b/iOSEngineerCodeCheck/Services/NetworkManager.swift
@@ -48,27 +48,4 @@ class NetworkManager {
     func cancelSearch() {
         searchTask?.cancel()
     }
-    
-    func fetchRepositoryImage(from urlString: String, completion: @escaping (Result<UIImage?, Error>) -> Void) {
-        guard let imgURL = URL(string: urlString) else {
-            let error = NSError(domain: "Invalid URL", code: -1, userInfo: nil)
-            completion(.failure(error))
-            return
-        }
-        fetchImage(from: imgURL, completion: completion)
-    }
-
-    private func fetchImage(from url: URL, completion: @escaping (Result<UIImage?, Error>) -> Void) {
-        URLSession.shared.dataTask(with: url) { data, _, error in
-            if let error = error {
-                completion(.failure(error))
-                return
-            }
-            if let data = data, let img = UIImage(data: data) {
-                completion(.success(img))
-            } else {
-                completion(.success(nil))
-            }
-        }.resume()
-    }
 }

--- a/iOSEngineerCodeCheck/Views/ViewControllers/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/Views/ViewControllers/RepositoryDetailViewController.swift
@@ -125,7 +125,7 @@ class RepositoryDetailViewController: UIViewController {
     }
     
     func fetchRepositoryImage(from urlString: String) {
-        NetworkManager.shared.fetchRepositoryImage(from: urlString) { [weak self] result in
+        GitHubRepositoryImageFetcher.shared.fetchRepositoryImage(from: urlString) { [weak self] result in
             switch result {
             case .success(let img):
                 DispatchQueue.main.async {

--- a/iOSEngineerCodeCheck/Views/ViewControllers/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/Views/ViewControllers/RepositorySearchViewController.swift
@@ -29,7 +29,7 @@ class RepositorySearchViewController: UIViewController, UITableViewDelegate, UIT
     
     // RepositorySearchViewControllerの破棄時に、URLSessionTaskを解放
     override func viewWillDisappear(_ animated: Bool) {
-        NetworkManager.shared.cancelSearch()
+        GitHubRepositorySearcher.shared.cancelSearch()
     }
     
     func setupUI() {
@@ -46,7 +46,7 @@ class RepositorySearchViewController: UIViewController, UITableViewDelegate, UIT
     }
     
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        NetworkManager.shared.cancelSearch()
+        GitHubRepositorySearcher.shared.cancelSearch()
     }
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
@@ -55,7 +55,7 @@ class RepositorySearchViewController: UIViewController, UITableViewDelegate, UIT
     }
 
     private func searchRepositories(with searchTerm: String) {
-        NetworkManager.shared.searchRepositories(with: searchTerm) { [weak self] result in
+        GitHubRepositorySearcher.shared.searchRepositories(with: searchTerm) { [weak self] result in
             guard let self = self else { return }
             self.handleSearchResult(result)
         }


### PR DESCRIPTION
### 修正内容
- NetworkManagerクラス内の処理がGitHubリポジトリの検索のみになったため、クラス名をGitHubRepositorySearcherに変更
- 画像フェッチ処理をGitHubRepositoryImageFetcherクラスに移動

### 修正理由
- クラスの責任を明確化し、単一責任原則に基づく設計にするため
- クラス名を変更することで、コードの可読性と理解しやすさを向上させるため
- 画像フェッチ処理を専用のクラスに分離することで、再利用性と保守性を向上させるため