### PR TITLE
refactor: ✨ #6 MVVMアーキテクチャへのリファクタリング

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		E28F1FA12C1E153E00591A37 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28F1FA02C1E153E00591A37 /* Extensions.swift */; };
 		E2E185702C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E1856F2C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift */; };
 		E2E185732C1F85B40086AA12 /* RepositorySearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E185722C1F85B40086AA12 /* RepositorySearchViewModel.swift */; };
+		E2E185772C1F97460086AA12 /* RepositoryDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E185762C1F97460086AA12 /* RepositoryDetailViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +60,7 @@
 		E28F1FA02C1E153E00591A37 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		E2E1856F2C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryImageFetcher.swift; sourceTree = "<group>"; };
 		E2E185722C1F85B40086AA12 /* RepositorySearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositorySearchViewModel.swift; sourceTree = "<group>"; };
+		E2E185762C1F97460086AA12 /* RepositoryDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -203,6 +205,7 @@
 			isa = PBXGroup;
 			children = (
 				E2E185722C1F85B40086AA12 /* RepositorySearchViewModel.swift */,
+				E2E185762C1F97460086AA12 /* RepositoryDetailViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -347,6 +350,7 @@
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				E2054CE42C1F15620044D738 /* RepositoryModel.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
+				E2E185772C1F97460086AA12 /* RepositoryDetailViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		E2054CE42C1F15620044D738 /* RepositoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2054CE32C1F15610044D738 /* RepositoryModel.swift */; };
 		E28F1FA12C1E153E00591A37 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28F1FA02C1E153E00591A37 /* Extensions.swift */; };
 		E2E185702C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E1856F2C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift */; };
+		E2E185732C1F85B40086AA12 /* RepositorySearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E185722C1F85B40086AA12 /* RepositorySearchViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +58,7 @@
 		E2054CE32C1F15610044D738 /* RepositoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryModel.swift; sourceTree = "<group>"; };
 		E28F1FA02C1E153E00591A37 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		E2E1856F2C1F67160086AA12 /* GitHubRepositoryImageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryImageFetcher.swift; sourceTree = "<group>"; };
+		E2E185722C1F85B40086AA12 /* RepositorySearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositorySearchViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,6 +112,7 @@
 				E288B0D82C1F2B9E00607ED0 /* Application */,
 				E288B0D92C1F2BAF00607ED0 /* Models */,
 				E288B0DA2C1F2BC100607ED0 /* Views */,
+				E2E185712C1F85890086AA12 /* ViewModels */,
 				E288B0DC2C1F2C0000607ED0 /* Services */,
 				E288B0DD2C1F2C1900607ED0 /* Helpers */,
 				E288B0DE2C1F2C2B00607ED0 /* Resources */,
@@ -194,6 +197,14 @@
 				BFD945EC244DC5EB0012785A /* Info.plist */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		E2E185712C1F85890086AA12 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				E2E185722C1F85B40086AA12 /* RepositorySearchViewModel.swift */,
+			);
+			path = ViewModels;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -327,6 +338,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E2E185732C1F85B40086AA12 /* RepositorySearchViewModel.swift in Sources */,
 				E2054CE22C1F150F0044D738 /* GitHubRepositorySearcher.swift in Sources */,
 				E28F1FA12C1E153E00591A37 /* Extensions.swift in Sources */,
 				BFD945E3244DC5E80012785A /* RepositorySearchViewController.swift in Sources */,

--- a/iOSEngineerCodeCheck/Services/GitHubRepositorySearcher.swift
+++ b/iOSEngineerCodeCheck/Services/GitHubRepositorySearcher.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2024 YUMEMI Inc. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 class GitHubRepositorySearcher {
     private var searchTask: URLSessionTask?

--- a/iOSEngineerCodeCheck/ViewModels/RepositoryDetailViewModel.swift
+++ b/iOSEngineerCodeCheck/ViewModels/RepositoryDetailViewModel.swift
@@ -1,0 +1,38 @@
+//
+//  RepositoryDetailViewModel.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 鈴木斗夢 on 2024/06/17.
+//  Copyright © 2024 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+protocol RepositoryDetailViewModelDelegate: AnyObject {
+    func updateRepositoryImage(_ image: UIImage?)
+    func showPlaceholderImage()
+}
+
+class RepositoryDetailViewModel {
+    private let repository: RepositoryModel
+    weak var delegate: RepositoryDetailViewModelDelegate?
+    
+    init(repository: RepositoryModel, delegate: RepositoryDetailViewModelDelegate) {
+        self.repository = repository
+        self.delegate = delegate
+    }
+    
+    func fetchRepositoryImage() {
+        let avatarURL = repository.owner.avatarURL
+        GitHubRepositoryImageFetcher.shared.fetchRepositoryImage(from: avatarURL) { [weak self] result in
+            guard let self = self else { return }
+            
+            switch result {
+            case .success(let image):
+                self.delegate?.updateRepositoryImage(image)
+            case .failure:
+                self.delegate?.showPlaceholderImage()
+            }
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/ViewModels/RepositorySearchViewModel.swift
+++ b/iOSEngineerCodeCheck/ViewModels/RepositorySearchViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  RepositorySearchViewModel.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 鈴木斗夢 on 2024/06/17.
+//  Copyright © 2024 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+protocol RepositorySearchViewModelDelegate: AnyObject {
+    func updateRepositories()
+    func showError(message: Error)
+}
+
+class RepositorySearchViewModel {
+    weak var delegate: RepositorySearchViewModelDelegate?
+    var searchRepositories: [RepositoryModel] = []
+    
+    init(delegate: RepositorySearchViewModelDelegate) {
+        self.delegate = delegate
+    }
+    
+    func searchRepositories(with searchTerm: String) {
+        GitHubRepositorySearcher.shared.searchRepositories(with: searchTerm) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let repositories):
+                self.searchRepositories = repositories
+                self.delegate?.updateRepositories()
+            case .failure(let error):
+                self.delegate?.showError(message: error)
+            }
+        }
+    }
+    
+    func cancelSearch() {
+        GitHubRepositorySearcher.shared.cancelSearch()
+    }
+}

--- a/iOSEngineerCodeCheck/Views/ViewControllers/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/Views/ViewControllers/RepositoryDetailViewController.swift
@@ -17,8 +17,9 @@ class RepositoryDetailViewController: UIViewController {
     let watchersCountLabel = UILabel()
     let forksCountLabel = UILabel()
     let openIssuesCountLabel = UILabel()
-    var repository: RepositoryModel?
-
+    var repository: RepositoryModel
+    var viewModel: RepositoryDetailViewModel!
+    
     init(repository: RepositoryModel) {
         self.repository = repository
         super.init(nibName: nil, bundle: nil)
@@ -30,9 +31,13 @@ class RepositoryDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.setupData()
         self.setupUI()
-        guard let repository = repository else { return }
-
+        viewModel = RepositoryDetailViewModel(repository: repository, delegate: self)
+        viewModel.fetchRepositoryImage()
+    }
+    
+    private func setupData() {
         repositoryNameLabel.text = repository.fullName
         programmingLanguageLabel.text = "Written in \(repository.language ?? "Unknown")"
         stargazersCountLabel.text = "\(repository.stargazersCount) stars"
@@ -136,8 +141,16 @@ class RepositoryDetailViewController: UIViewController {
             }
         }
     }
+}
+
+extension RepositoryDetailViewController: RepositoryDetailViewModelDelegate {
+    func updateRepositoryImage(_ image: UIImage?) {
+        DispatchQueue.main.async {
+            self.repositoryImageView.image = image
+        }
+    }
     
-    private func showPlaceholderImage() {
+    func showPlaceholderImage() {
         DispatchQueue.main.async {
             let placeholderImage = UIImage(named: "placeholder")
             self.repositoryImageView.image = placeholderImage


### PR DESCRIPTION
### 修正内容
- RepositoryDetailViewModelクラスを作成し、リポジトリ画像のフェッチロジックを移動
- RepositoryDetailViewControllerからビジネスロジックを分離
- Delegateパターンを使用してViewModelとViewController間のデータ更新を実装
- GitHubRepositorySearcherクラスのインポートをUIKitからFoundationに変更

### 修正理由
- MVVMアーキテクチャに移行することで、コードの可読性と保守性を向上させるため
- ビューとロジックの分離を行い、単一責任の原則を遵守するため

---

### 修正内容
- RepositorySearchViewModelクラスを作成し、検索処理を移動
- RepositorySearchViewControllerクラスからビジネスロジックを分離
- Delegateパターンを使用してViewModelとViewController間のデータ更新を実装
- テーブルビューのデリゲートとデータソースをエクステンションに分離

### 修正理由
- MVVMアーキテクチャに移行することで、コードの可読性と保守性を向上させるため
- ビューとロジックの分離を行い、単一責任の原則を遵守するため
