### PR TITLE
feat: 🐛 #7 検索バーのキーボード閉じる動作を追加

### DIFF
--- a/iOSEngineerCodeCheck/Views/ViewControllers/RepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/Views/ViewControllers/RepositorySearchViewController.swift
@@ -47,6 +47,7 @@ extension RepositorySearchViewController: UISearchBarDelegate {
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let searchTerm = searchBar.text, !searchTerm.isEmpty else { return }
+        searchBar.resignFirstResponder() // キーボードを閉じる
         viewModel.searchRepositories(with: searchTerm)
     }
 }
@@ -98,4 +99,9 @@ extension RepositorySearchViewController: RepositorySearchViewModelDelegate {
         present(alertController, animated: true, completion: nil)
     }
 }
-
+// UIScrollViewDelegateのメソッドをUITableViewDelegateの拡張として実装
+extension RepositorySearchViewController {
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        searchBar.resignFirstResponder() // キーボードを閉じる
+    }
+}


### PR DESCRIPTION
### 修正内容
- 検索ボタンを押した際にキーボードを閉じる処理を追加
- テーブルビューのスクロール開始時にキーボードを閉じる処理を追加

### 修正理由
- ユーザー体験を向上させるために、検索ボタンを押した後やテーブルビューをスクロールした際にキーボードを自動的に閉じるようにしました。